### PR TITLE
fix QoS argument position

### DIFF
--- a/src/bringup/Turtlebot.cpp
+++ b/src/bringup/Turtlebot.cpp
@@ -9,9 +9,6 @@ using namespace std;
 
 
 Turtlebot::Turtlebot() : Node("Turtlebot"){
-    // Quality of Service
-    rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
-    custom_qos_profile.depth = 7;
 
     kobuki = createKobuki(KobukiStringArgument(device_special));
 
@@ -19,16 +16,32 @@ Turtlebot::Turtlebot() : Node("Turtlebot"){
 
     velocity = this->create_subscription<geometry_msgs::msg::Twist>(
         "turtlebot2/commands/velocity",
-        custom_qos_profile,
+        10,
         [this](geometry_msgs::msg::Twist::SharedPtr msg) {
             getVelocity(msg);
         }
     );
 
-    odom = this->create_publisher<nav_msgs::msg::Odometry>("turtlebot2/odometry", custom_qos_profile);
+    reset = this->create_subscription<std_msgs::msg::Bool>(
+        "turtlebot2/commands/reset_pose",
+	10,
+	[this](std_msgs::msg::Bool::SharedPtr msg) {
+	    resetPose(msg);
+	}
+    );
+
+    odom = this->create_publisher<nav_msgs::msg::Odometry>(
+        "turtlebot2/odometry",
+	10
+    );
+
     odometryTimer = this->create_wall_timer(20ms, bind(&Turtlebot::publishOdometry, this));
 
-    inertial = this->create_publisher<sensor_msgs::msg::Imu>("turtlebot2/imu", custom_qos_profile);
+    inertial = this->create_publisher<sensor_msgs::msg::Imu>(
+        "turtlebot2/imu",
+        10
+    );
+
     inertialTimer = this->create_wall_timer(20ms, bind(&Turtlebot::publishInertial, this));
 }
 

--- a/src/bringup/Turtlebot.hpp
+++ b/src/bringup/Turtlebot.hpp
@@ -47,6 +47,7 @@ class Turtlebot :
     
             // init subscription
             rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr velocity;
+	    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr reset;
     
             // init publisher
             rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr battery;


### PR DESCRIPTION
1. 引数の指定時にQoS Depthナンバーの位置が間違っている点の修正.

2. ロボットの姿勢をリセットするためのresetPose関数を実装.
3. 姿勢のリセットを行うためのsubscription topicを作成.
姿勢リセットを行う場合はtopicに対してBool型にてTrueを送信することでできる.